### PR TITLE
feat: http timeout

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,22 +21,22 @@ paste = "1.0.15"
 rustls = { version = "0.23.25", features = ["ring"] }
 serde_json = "1.0.140"
 tokio = { version = "1.44.1", features = ["full"] }
-tower = "0.4.13"
+tower = { version = "0.4.13", features = ["timeout"] }
 tower-http = { version = "0.6.2", features = ["decompression-full"] }
 tracing = "0.1.41"
-tracing-subscriber = {version = "0.3.19", features = ["env-filter", "json"] }
+tracing-subscriber = { version = "0.3.19", features = ["env-filter", "json"] }
 metrics-exporter-prometheus = "0.16.2"
 metrics-util = "0.19.0"
 opentelemetry = { version = "0.28.0", features = ["trace"] }
 opentelemetry-otlp = { version = "0.28.0", features = [
-    "http-proto",
-    "http-json",
-    "reqwest-client",
-    "trace",
-    "grpc-tonic",
+  "http-proto",
+  "http-json",
+  "reqwest-client",
+  "trace",
+  "grpc-tonic",
 ] }
 opentelemetry_sdk = { version = "0.28.0", features = ["rt-tokio"] }
-tracing-opentelemetry =  "0.29.0"
+tracing-opentelemetry = "0.29.0"
 futures = "0.3.31"
 
 [dev-dependencies]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -329,9 +329,9 @@ macro_rules! define_rpc_args {
 
                     pub fn build(&self) -> Result<FanoutWrite> {
                         let jwt = self.get_jwt()?;
-                        let client_0 = HttpClient::new(self.[<$prefix _url_0>].clone(), jwt.clone());
-                        let client_1 = HttpClient::new(self.[<$prefix _url_1>].clone(), jwt.clone());
-                        let client_2 = HttpClient::new(self.[<$prefix _url_2>].clone(), jwt);
+                        let client_0 = HttpClient::new(self.[<$prefix _url_0>].clone(), jwt.clone(), self.[<$prefix _timeout>],);
+                        let client_1 = HttpClient::new(self.[<$prefix _url_1>].clone(), jwt.clone(), self.[<$prefix _timeout>]);
+                        let client_2 = HttpClient::new(self.[<$prefix _url_2>].clone(), jwt, self.[<$prefix _timeout>]);
                         Ok(FanoutWrite::new(vec![client_0, client_1, client_2]))
                     }
                 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -329,7 +329,7 @@ macro_rules! define_rpc_args {
 
                     pub fn build(&self) -> Result<FanoutWrite> {
                         let jwt = self.get_jwt()?;
-                        let client_0 = HttpClient::new(self.[<$prefix _url_0>].clone(), jwt.clone(), self.[<$prefix _timeout>],);
+                        let client_0 = HttpClient::new(self.[<$prefix _url_0>].clone(), jwt.clone(), self.[<$prefix _timeout>]);
                         let client_1 = HttpClient::new(self.[<$prefix _url_1>].clone(), jwt.clone(), self.[<$prefix _timeout>]);
                         let client_2 = HttpClient::new(self.[<$prefix _url_2>].clone(), jwt, self.[<$prefix _timeout>]);
                         Ok(FanoutWrite::new(vec![client_0, client_1, client_2]))

--- a/src/client.rs
+++ b/src/client.rs
@@ -38,13 +38,12 @@ impl HttpClient {
             .enable_http2()
             .build();
 
-        let client = Client::builder(TokioExecutor::new()).build(connector);
-
+        let client_builder = Client::builder(TokioExecutor::new());
         let client = ServiceBuilder::new()
             .layer(TimeoutLayer::new(Duration::from_millis(timeout)))
             .layer(DecompressionLayer::new())
             .layer(AuthClientLayer::new(secret))
-            .service(client);
+            .service(client_builder.build(connector));
 
         Self { client, url }
     }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -127,32 +127,38 @@ mod tests {
                 format!("http://{}:{}", builder_0.addr.ip(), builder_0.addr.port())
                     .parse::<Uri>()?,
                 JwtSecret::random(),
+                1000,
             );
 
             let builder_1_http_client = TxProxyHttpClient::new(
                 format!("http://{}:{}", builder_1.addr.ip(), builder_1.addr.port())
                     .parse::<Uri>()?,
                 JwtSecret::random(),
+                1000,
             );
             let builder_2_http_client = TxProxyHttpClient::new(
                 format!("http://{}:{}", builder_2.addr.ip(), builder_2.addr.port())
                     .parse::<Uri>()?,
                 JwtSecret::random(),
+                1000,
             );
 
             let l2_0_http_client = TxProxyHttpClient::new(
                 format!("http://{}:{}", l2_0.addr.ip(), l2_0.addr.port()).parse::<Uri>()?,
                 JwtSecret::random(),
+                1000,
             );
 
             let l2_1_http_client = TxProxyHttpClient::new(
                 format!("http://{}:{}", l2_1.addr.ip(), l2_1.addr.port()).parse::<Uri>()?,
                 JwtSecret::random(),
+                1000,
             );
 
             let l2_2_http_client = TxProxyHttpClient::new(
                 format!("http://{}:{}", l2_2.addr.ip(), l2_2.addr.port()).parse::<Uri>()?,
                 JwtSecret::random(),
+                1000,
             );
 
             let builder_fanout = FanoutWrite::new(vec![


### PR DESCRIPTION
This PR adds a `TimeoutLayer` to the HTTP client initialization logic:

```rust
impl HttpClient {
    pub fn new(url: Uri, secret: JwtSecret, timeout: u64) -> Self {
     // --snip--
        let client = ServiceBuilder::new()
            .layer(TimeoutLayer::new(Duration::from_millis(timeout)))
            .layer(DecompressionLayer::new())
            .layer(AuthClientLayer::new(secret))
            .service(client_builder.build(connector));

        Self { client, url }
    }


```