### PR TITLE
Restart server is metrics server ever crashes

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -120,7 +120,6 @@ impl Cli {
             _ = tokio::signal::ctrl_c() => {
                 error!("Received Ctrl-C, shutting down...");
                 shutdown_handle.stop()?;
-                // metrics_handle.abort();
                 Ok(())
             }
             _ = sigterm.recv() => {
@@ -136,6 +135,7 @@ impl Cli {
                 } else {
                     Ok(())
                 }
+            }
         }
     }
 


### PR DESCRIPTION
Handle both cases for metrics server crashes
1. Not able to bind to IP on launch
2. Crashes after program has started